### PR TITLE
Add Irish translations

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ app = Flask(__name__)
 env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
 
 template_langs = {
-    'en': '',
+    'en': 'en',
     'ga': 'ga'
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,5 @@
+{% set langvalues = lang + '/values.html' %}
+{% import langvalues as langvalues %}
 <!doctype html>
 <head>
     <meta charset="utf-8">
@@ -5,10 +7,10 @@
     <link rel="stylesheet" href="https://unpkg.com/tachyons@4.5.3/css/tachyons.min.css"/>
 </head>
 <body style="background-color:#fffcfb" class="obg-washed-yellow pv1 ph4 mv1 mh4 f4 tc">
-<a href="/" style="text-decoration:none"><p class="f1 b mb0 no-underline green">www.safer.place</p></a>
-<p class="f5 mt1 mb0">By <a style="text-decoration:none" class="green" href="http://binarysear.ch">Cian Ruane</a> and <a style="text-decoration:none" class="green" href="http://noah.needs.money">Noah Ó Donnaile</a></p>
+<a href="/?lang={{lang}}" style="text-decoration:none"><p class="f1 b mb0 no-underline green">www.safer.place</p></a>
+<p class="f5 mt1 mb0">{{ langvalues.subtitle }}</p>
 <br/>
 {% block body %}
-oh shit
+body
 {% endblock %}
 </body>

--- a/templates/details.html
+++ b/templates/details.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %}
 {% block body %}
-    <p><span class="b">Your input</span>: {{ input|e }}</p>
-    <p><span class="b">Where we think this is</span>: {{ address|e }}</p>
-    <p><span class="b">Precise coordinates</span>: {{ '{:.3f}'.format(coord_x) | e }}, {{ '{:.3f}'.format(coord_y) | e}}</p>
+    <p><span class="b">{% block yourInputLabel %}yourInputLabel{% endblock %}</span>: {{ input|e }}</p>
+    <p><span class="b">{% block actualAddressLabel %}actualAddressLabel{% endblock %}</span>: {{ address|e }}</p>
+    <p><span class="b">{% block coordinateLabel %}coorinateLabel{% endblock %}</span>: {{ '{:.3f}'.format(coord_x) | e }}, {{ '{:.3f}'.format(coord_y) | e}}</p>
     <br/>
-    <p><span class="b">Area Safety Score</span>: <span {% if rounded_score <= 2 %} style="color:#f00" {% elif rounded_score == 3 %} class="orange" {% else %} class="green" {% endif %}>{% for item in range(rounded_score)%} &#9733; {% endfor %}{% for item in range(5-rounded_score) %} &#9734; {% endfor %} ({{ "{:.2f}".format(true_score) }})</span></p>
-    <p>The higher the safety score (the more stars you have), the safer the area!</p>
+    <p><span class="b">{% block safetyScoreLabel %}safetyScoreLabel{% endblock %}</span>: <span {% if rounded_score <= 2 %} style="color:#f00" {% elif rounded_score == 3 %} class="orange" {% else %} class="green" {% endif %}>{% for item in range(rounded_score)%} &#9733; {% endfor %}{% for item in range(5-rounded_score) %} &#9734; {% endfor %} ({{ "{:.2f}".format(true_score) }})</span></p>
+    <p>{% block safetyScoreDescription %}safetyScoreDescription{% endblock %}</p>
     <script src="https://unpkg.com/leaflet@1.0.1/dist/leaflet.js"></script>
     <link href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" rel="stylesheet"/>
     <div id="osm-map"></div>

--- a/templates/en/details.html
+++ b/templates/en/details.html
@@ -1,0 +1,6 @@
+{% extends 'details.html' %}
+{% block yourInputLabel %}Your input{% endblock %}
+{% block actualAddressLabel %}Where we think this is{% endblock %}
+{% block coordinateLabel %}Precise coordinates{% endblock %}
+{% block safetyScoreLabel %}Area Safety Score{% endblock %}
+{% block safetyScoreDescription %}The higher the safety score (the more stars you have), the safer the area!{% endblock %}

--- a/templates/en/error.html
+++ b/templates/en/error.html
@@ -1,0 +1,2 @@
+{% extends 'en/index.html' %}
+{% block blurb %}Could not find the location you entered ("<span class="green code">{{ input| e }}</span>")! Please try a different location.{% endblock %}

--- a/templates/en/index.html
+++ b/templates/en/index.html
@@ -1,0 +1,4 @@
+{% extends 'index.html' %}
+{% block blurb %}Have you found a property somewhere in Ireland, but you aren't familiar with the area?<br>This tool will give you some information about your potential future home, and help you decide if it's the place for you!{% endblock %}
+{% block pleaseEnterLabel %}Please enter an eircode{% endblock %}
+{% block submitText %}Let's go!{% endblock %}

--- a/templates/en/values.html
+++ b/templates/en/values.html
@@ -1,0 +1,2 @@
+{% set subtitle='By <a style="text-decoration:none" class="green" href="http://binarysear.ch">Cian Ruane</a> and <a style="text-decoration:none" class="green" href="http://noah.needs.money">Noah Ó Donnaile</a>' %}
+{% set submitText="Let's go!" %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,4 +1,4 @@
-{% extends 'index.html' %}
-{% block blurb %}
-<p>Could not find the location you entered ("<span class="green code">{{ input| e }}</span>")! Please try a different location.</p>
-{% endblock %}
+{# This template should never be called directly. It should be in a language subdirectory, with the following format: 
+    {% extends '<this_lang>/index.html' %}
+    {% block blurb %}Error text in <this_lang>{% endblock %}
+#}

--- a/templates/ga/details.html
+++ b/templates/ga/details.html
@@ -1,1 +1,6 @@
 {% extends 'details.html' %}
+{% block yourInputLabel %}D'ionchur{% endblock %}
+{% block actualAddressLabel %}Cá cheapaimid gurbh é seo{% endblock %}
+{% block coordinateLabel %}Comhordanáidí beachta{% endblock %}
+{% block safetyScoreLabel %}Scór sábháilteachta an cheantair{% endblock %}
+{% block safetyScoreDescription %}Dá airde an scór (agus an uimhir réaltaí) is ea is sábhailte an áit é!{% endblock %}

--- a/templates/ga/error.html
+++ b/templates/ga/error.html
@@ -1,2 +1,2 @@
 {% extends 'ga/index.html' %}
-{% block blurb %}Ní rabhamar in ann an áit a thug tú a aimsiú! Bain triail eile as, le do thoil!{% endblock %}
+{% block blurb %}Ní rabhamar in ann an áit a thug tú ("<span class="green code">{{ input| e }}</span>") a aimsiú! Bain triail eile as, le do thoil!{% endblock %}

--- a/templates/ga/error.html
+++ b/templates/ga/error.html
@@ -1,4 +1,2 @@
-{% extends 'error.html' %}
-{% block blurb %}
-<p>Ní rabhamar in ann an áit a thug tú a aimsiú! Bain triail eile as, le do thoil!</p>
-{% endblock %}
+{% extends 'ga/index.html' %}
+{% block blurb %}Ní rabhamar in ann an áit a thug tú a aimsiú! Bain triail eile as, le do thoil!{% endblock %}

--- a/templates/ga/index.html
+++ b/templates/ga/index.html
@@ -1,4 +1,4 @@
 {% extends 'index.html' %}
-{% block blurb %}
-    <p>Ar aimsigh tú teach áit éigin in Éirinn, ach níl aithne agat ar an gceantar?<br>This tool will give you some information about your potential future home, and help you decide if it's the place for you!</p>
-{% endblock %}
+{% block blurb %}Ar aimsigh tú teach áit éigin in Éirinn, ach níl aithne agat ar an gceantar?<br>This tool will give you some information about your potential future home, and help you decide if it's the place for you!{% endblock %}
+{% block pleaseEnterLabel %}Tabhair seoladh, le do thoil{% endblock %}
+{% block submitText %}Ar aghaidh linn!{% endblock %}

--- a/templates/ga/index.html
+++ b/templates/ga/index.html
@@ -1,4 +1,4 @@
 {% extends 'index.html' %}
-{% block blurb %}Ar aimsigh tú teach áit éigin in Éirinn, ach níl aithne agat ar an gceantar?<br>This tool will give you some information about your potential future home, and help you decide if it's the place for you!{% endblock %}
+{% block blurb %}Ar aimsigh tú teach áit éigin in Éirinn, ach níl aithne agat ar an gceantar?<br>Cabhróidh an uirlis seo leat, ag tabhairt eolas faoi do bhaile sa todhchaí, agus ag cuidiú leat a shocrú gurbh é an áit duit!{% endblock %}
 {% block pleaseEnterLabel %}Tabhair seoladh, le do thoil{% endblock %}
 {% block submitText %}Ar aghaidh linn!{% endblock %}

--- a/templates/ga/values.html
+++ b/templates/ga/values.html
@@ -1,0 +1,4 @@
+{#
+    This file should be used to set values that are constant across every page on the site in a given language.
+#}
+{% set subtitle='Le <a style="text-decoration:none" class="green" href="http://binarysear.ch">Cian Ruane</a> agus <a style="text-decoration:none" class="green" href="http://noah.needs.money">Noah Ó Donnaile</a>' %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
 {% block body %}
-{% block blurb %}
-    <p>Have you found a property somewhere in Ireland, but you aren't familiar with the area?<br>This tool will give you some information about your potential future home, and help you decide if it's the place for you!</p>
-{% endblock %}
+<p>{% block blurb %}blurb{% endblock %}</p>
 	<br/>
-    <p>Please enter an eircode:</p>
+    <p>{{ langvalues.pleaseEnterLabel }}</p>
+    <p>{% block pleaseEnterLabel %}pleaseEnterLabel{% endblock %}:</p>
     <form action="/details" method="get">
     <input type="text" name="input" value="D08 PX8H"></input>
     <input type="hidden" name="lang" value="{{ lang }}"></input>
-    <input type="submit" value="Let's go!"></input>
+    <input type="submit" value="{% block submitText %}submitText{% endblock %}"></input>
     </form>
 {% endblock %}
+Lang values = "{{ langvalues.submitText }}"

--- a/templates/values.html
+++ b/templates/values.html
@@ -1,0 +1,4 @@
+{#
+    This file should be used to set values that are constant across every page on the site in a given language.
+#}
+{% set subtitle='By <a style="text-decoration:none" class="green" href="http://binarysear.ch">Cian Ruane</a> and <a style="text-decoration:none" class="green" href="http://noah.needs.money">Noah Ó Donnaile</a>' %}


### PR DESCRIPTION
Connects to #7.

Also:

- Makes header include a language attribute, so that it doesn't change languages when you go back to the index page
- Rejigs the template system

Does not:

- Mention that there exists an Irish version